### PR TITLE
[API-424] add support for working directory in common severless deployments

### DIFF
--- a/.github/workflows/serverless_node_deploy.yml
+++ b/.github/workflows/serverless_node_deploy.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/serverless_node_deploy.yml
+++ b/.github/workflows/serverless_node_deploy.yml
@@ -9,6 +9,11 @@ on:
         type: string
         required: false
         default: 12.x
+      working-directory:
+        type: string
+        required: false
+        default: './'
+        description: Relative path within repo to use for deployment action. Trailing slash required.
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -18,6 +23,10 @@ on:
         required: true
       SLACK_BOT_TOKEN:
         required: true
+
+defaults:
+  run:
+    working-directory: ${{ inputs.working-directory }}
 jobs:
   deploy:
     runs-on: ubuntu-20.04
@@ -29,6 +38,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}package-lock.json
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/README.md
+++ b/README.md
@@ -16,8 +16,29 @@ Current workflows:
     "deploy:prod": "serverless deploy -s prod"
   }
 ```
-* Add `aws.yml` workflow in `.github/workflows/` dir, example:
+* Add shared job to workflow definition in `.github/workflows/` dir. Example job definition:
+```yaml
+jobs:
+  deploy:
+    uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
+    with:
+      # The environment to deploy to. Corresponds to the equivalent npm `deploy:*` script
+      stage: dev 
+      # Optional override of the node version to use when building/deploying
+      node-version: 14.x
+      # Optional override of the working directory. Useful for selecting a single project from a monorepo.
+      # Default is the root of the repo.
+      working-directory: ./foo/
+    secrets:
+      # Used to connect to the AWS API and trigger deployments
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      # Used for notification of CI/CD success or failure
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+```
 
+* Example full workflow definition:
 ```yaml
 name: CD/CI
 on:
@@ -46,6 +67,7 @@ jobs:
     uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
     with:
       stage: 'qa'
+      node-version: 14.x
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -58,6 +80,7 @@ jobs:
     uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
     with:
       stage: 'prod'
+      node-version: 14.x
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Some of our newer repos have multiple projects defined within them, which makes it impossible to utilize the common workflow unless serverless is setup at the top level, which is not ideal.

Additionally updated dependencies to support the deprecation of Node 12 in GH Actions.