### PR TITLE
[API-424] Fix error by applying default at job instead of workflow

### DIFF
--- a/.github/workflows/serverless_node_deploy.yml
+++ b/.github/workflows/serverless_node_deploy.yml
@@ -24,12 +24,12 @@ on:
       SLACK_BOT_TOKEN:
         required: true
 
-defaults:
-  run:
-    working-directory: ${{ inputs.working-directory }}
 jobs:
   deploy:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
https://tradeswell.atlassian.net/browse/API-424

Should hopefully fix this error:
```
The workflow is not valid. In .github/workflows/dev.yml (Line: 14, Col: 11): Error from called workflow Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main (Line: 29, Col: 24): Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.working-directory
```