### PR TITLE
[API-793] Update dependencies for serverless node deployment action

### DIFF
--- a/.github/workflows/serverless_node_deploy.yml
+++ b/.github/workflows/serverless_node_deploy.yml
@@ -7,8 +7,15 @@ on:
         required: true
       node-version:
         type: string
+        required: true
+      notifyOnSuccess:
+        type: boolean
         required: false
-        default: 12.x
+        default: true
+      notifyOnFailure:
+        type: boolean
+        required: false
+        default: true
       working-directory:
         type: string
         required: false
@@ -26,23 +33,23 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm
           cache-dependency-path: ${{ inputs.working-directory }}package-lock.json
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -54,16 +61,16 @@ jobs:
           npm run deploy:${{ inputs.stage }}
 
       - name: Failure Notification
-        if: ${{ failure() }}
-        uses: kpritam/slack-job-status-action@v0.1.2
+        if: ${{ failure() && inputs.notifyOnFailure == true }}
+        uses: kpritam/slack-job-status-action@v1
         with:
           job-status: ${{ job.status }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel: tw-development
 
       - name: Release Notification
-        if: ${{ success() }}
-        uses: kpritam/slack-job-status-action@v0.1.2
+        if: ${{ success() && inputs.notifyOnSuccess == true }}
+        uses: kpritam/slack-job-status-action@v1
         with:
           job-status: ${{ job.status }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,11 +22,17 @@ jobs:
   deploy:
     uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
     with:
-      # The environment to deploy to. Corresponds to the equivalent npm `deploy:*` script
+      # REQUIRED: The environment to deploy to. Corresponds to the equivalent npm `deploy:*` script
       stage: dev 
-      # Optional override of the node version to use when building/deploying
-      node-version: 14.x
-      # Optional override of the working directory. Useful for selecting a single project from a monorepo.
+      # REQUIRED: node version to use when building/deploying
+      node-version: 20.x
+      # OPTIONAL: whether to notify #tw-releases slack channel
+      # when successfully deployed
+      notifyOnSuccess: true
+      # OPTIONAL: whether to notify #tw-development slack channel
+      # when deployment fails
+      notifyOnFailure: true
+      # OPTIONAL: override of the working directory. Useful for selecting a single project from a monorepo.
       # Default is the root of the repo.
       working-directory: ./foo/
     secrets:
@@ -66,8 +72,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
     with:
-      stage: 'qa'
-      node-version: 14.x
+      stage: qa
+      node-version: 20.x
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -79,8 +85,8 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     uses: Tradeswell/shared-workflows/.github/workflows/serverless_node_deploy.yml@main
     with:
-      stage: 'prod'
-      node-version: 14.x
+      stage: prod
+      node-version: 20.x
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
https://tradeswell.atlassian.net/browse/API-793

This introduces a breaking change by choice to make the node-version a required parameter.
The expectation is that the caller should know what version it needs to run at, and therefore should not run a deprecated version by default.