### PR TITLE
[API-1029] Read job status from parent instead of composite action

### DIFF
--- a/actions/build-status-alert/action.yml
+++ b/actions/build-status-alert/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Failure Notification
-      if: ${{ failure() && inputs.notify-failure == 'true' }}
+      if: ${{ job.status == 'failure' && inputs.notify-failure == 'true' }}
       uses: kpritam/slack-job-status-action@v1
       with:
         job-status: ${{ job.status }}
@@ -30,7 +30,7 @@ runs:
         channel: ${{ inputs.channel-failure }}
 
     - name: Release Notification
-      if: ${{ success() && inputs.notify-success == 'true' }}
+      if: ${{ job.status == 'success' && inputs.notify-success == 'true' }}
       uses: kpritam/slack-job-status-action@v1
       with:
         job-status: ${{ job.status }}


### PR DESCRIPTION
Using failure() and success() in the composite action only reads the failure and success state from the composite action, not the parent.  Meaning that the success step was being called in every scenario.  This lead to failure messages occurring since the job.status being used in the underlying call read from the parent, however; they were being sent to the wrong success channel.