### PR TITLE
[API-XXXX] Allow passing of job status from caller as an override

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
         uses: Tradeswell/shared-workflows/actions/build-status-alert@main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          job-status: ${{ needs.build.result }} # OPTIONAL - overrides job.status for when notification is in a separate job from the action being performed and must be calculated.
           notify-success: 'true' # OPTIONAL
           notify-failure: 'true' # OPTIONAL
           channel-success: 'tw-releases' # OPTIONAL

--- a/actions/build-status-alert/action.yml
+++ b/actions/build-status-alert/action.yml
@@ -5,6 +5,9 @@ inputs:
   slack-bot-token:
     description: Slack Webhook Token
     required: true
+  job-status:
+    description: 'Override job status (e.g. computed from needs context). Falls back to job.status if not provided.'
+    default: ''
   notify-success:
     description: If alert should be triggered if workflow succeeded
     default: 'true'
@@ -22,17 +25,17 @@ runs:
   using: composite
   steps:
     - name: Failure Notification
-      if: ${{ job.status == 'failure' && inputs.notify-failure == 'true' }}
+      if: ${{ (inputs.job-status || job.status) == 'failure' && inputs.notify-failure == 'true' }}
       uses: kpritam/slack-job-status-action@v1
       with:
-        job-status: ${{ job.status }}
+        job-status: ${{ inputs.job-status || job.status }}
         slack-bot-token: ${{ inputs.slack-bot-token }}
         channel: ${{ inputs.channel-failure }}
 
     - name: Release Notification
-      if: ${{ job.status == 'success' && inputs.notify-success == 'true' }}
+      if: ${{ (inputs.job-status || job.status) == 'success' && inputs.notify-success == 'true' }}
       uses: kpritam/slack-job-status-action@v1
       with:
-        job-status: ${{ job.status }}
+        job-status: ${{ inputs.job-status || job.status }}
         slack-bot-token: ${{ inputs.slack-bot-token }}
         channel: ${{ inputs.channel-success }}


### PR DESCRIPTION
https://tradeswell.slack.com/archives/C025FHTNVSR/p1771604785456529

Was using job status as all previous usage of the workflow was within a single job.

However in order to reduce extra notifications due to a split deployment process, ds-ml-platform uses this job in a summary form.

Previously, would use job.status only, but in the standalone notification use case, it would always succeed as it is a single step (the notification itself).

This update allows the caller to calculate their own job status which will override if passed.
This should allow both use cases (within preexisting job, or standalone) to correctly alert their status.